### PR TITLE
Add Oracle Linux support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ bin/*
 Berksfile.lock
 .zero-knife.rb
 Policyfile.lock.json
+
+# RubyMine
+.idea/

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,6 +13,9 @@ platforms:
 - name: centos-6.5
   run_list:
   - recipe[build-essential]
+- name: oracle-7.3
+  run_list:
+  - recipe[build-essential]
 
 suites:
 - name: system_python

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,7 +18,7 @@ default['pyenv']['user_pythons'] = []
 # whether to create profile.d shell script
 default['pyenv']['create_profiled'] = true
 
-if platform?('redhat', 'centos', 'fedora', 'amazon', 'scientific')
+if platform?('redhat', 'centos', 'fedora', 'amazon', 'scientific', 'oracle')
   default['pyenv']['install_pkgs'] = %w[
     bzip2 bzip2-devel
     git


### PR DESCRIPTION
Adding `oracle` to the attribute default handling code makes the pyenv cookbook work on Oracle Linux.

I needed to set `chef_omnibus_version` in TK to 12.x in order to avoid an existing incompatibility with Chef 13, calling `platform` from the attributes file.