### PR TITLE
Invoke pip install only necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 <!-- Add your contributions here. -->
 
+* invoke `pip install` only necessary #34
 * deprecate support for Chef 13 due to [EOL][supported-versions]
 * update cookbook to use `apt_update` and `build_essential` resources from Chef 14 make sure builds don't failed because of lack of packages
 

--- a/libraries/chef_pyenv_script_helpers.rb
+++ b/libraries/chef_pyenv_script_helpers.rb
@@ -1,6 +1,9 @@
+require 'chef/mixin/shell_out'
+
 class Chef
   module Pyenv
     module ScriptHelpers
+      include Chef::Mixin::ShellOut
       def root_path
         node.run_state['root_path'] ||= {}
 
@@ -41,6 +44,20 @@ class Chef
         end
 
         script_env
+      end
+
+      def pip_command(command)
+        pip = if new_resource.virtualenv
+                "#{new_resource.virtualenv}/bin/pip"
+              else
+                'pip'
+              end
+
+        shell_out("#{pip} #{command}",
+                  :environment => {
+                    'PATH' => "#{root_path}/shims:#{ENV['PATH']}",
+                  },
+                  :user => new_resource.user,)
       end
     end
   end

--- a/libraries/chef_pyenv_script_helpers.rb
+++ b/libraries/chef_pyenv_script_helpers.rb
@@ -54,10 +54,10 @@ class Chef
               end
 
         shell_out("#{pip} #{command}",
-                  :environment => {
+                  environment: {
                     'PATH' => "#{root_path}/shims:#{ENV['PATH']}",
                   },
-                  :user => new_resource.user,)
+                  user: new_resource.user)
       end
     end
   end

--- a/resources/pip.rb
+++ b/resources/pip.rb
@@ -89,17 +89,15 @@ action_class do
     current_version = nil
     show = pip_command("show #{new_resource.package_name}").stdout
     show.split(/\n+/).each do |line|
-      if line.start_with?('Version:')
-        current_version = line.split(/\s+/)[1]
-      end
+      current_version = line.split(/\s+/)[1] if line.start_with?('Version:')
     end
     Chef::Log.debug("current_version: #{new_resource.package_name} #{current_version}")
-    if !current_version
+    unless current_version
       Chef::Log.debug("not installed: #{new_resource.package_name}")
       return true
     end
 
-    if !new_resource.version
+    unless new_resource.version
       Chef::Log.debug("already installed: #{new_resource.package_name} #{current_version}")
       return false
     end


### PR DESCRIPTION
### Description

`pyenv_pip` don't converge (`pip install`) when the target package is already installed.

master:
```
* pyenv_pip[requests] action install
  * pyenv_script[requests] action run
    * bash[requests] action run
      - execute "bash" -e "/tmp/chef-script20190612-27241-q5joh5"
```

This PR:
```
* pyenv_pip[requests] action install
  * pyenv_script[requests] action run (skipped due to only_if)
   (up to date)
```

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] Changes have been added to `CHANGELOG.md`
